### PR TITLE
Problem: Moderators cannot promote new moderators (#118)

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -41,3 +41,4 @@ accounts-github
 accounts-google
 service-configuration
 random
+littledata:synced-cron

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -56,6 +56,7 @@ kadira:blaze-layout@2.3.0
 kadira:flow-router@2.12.1
 launch-screen@1.1.1
 less@2.7.12
+littledata:synced-cron@1.5.1
 livedata@1.0.18
 lmieulet:meteor-coverage@2.0.2
 localstorage@1.2.0

--- a/imports/api/user/server/publications.js
+++ b/imports/api/user/server/publications.js
@@ -9,7 +9,8 @@ Meteor.publish(null, () => Meteor.users.find({
 		profile: 1,
 		suspended: 1,
 		pardon: 1,
-		strikes: 1
+		strikes: 1,
+		mod: 1
 	}
 }))
 
@@ -20,6 +21,7 @@ Meteor.publish('users', () => Meteor.users.find({}, {
 		profile: 1,
 		suspended: 1,
 		pardon: 1,
-		strikes: 1
+		strikes: 1,
+		mod: 1
 	}
 }))

--- a/imports/api/user/server/startup.js
+++ b/imports/api/user/server/startup.js
@@ -1,0 +1,11 @@
+import { Meteor } from 'meteor/meteor'
+
+import { possibleModerators } from '../methods'
+
+Meteor.startup(() => {
+    SyncedCron.add({
+        name: 'Fetch possible moderators',
+        schedule: (parser) => parser.cron('0 */6 * * *'), // every 6 hours will be sufficient
+        job: () => possibleModerators.call({}, (err, data) => {})
+    })
+})

--- a/imports/startup/client/routes.js
+++ b/imports/startup/client/routes.js
@@ -18,6 +18,7 @@ import '/imports/ui/pages/suspended/suspended'
 
 import '/imports/ui/pages/moderator/flagged/flaggedItems'
 import '/imports/ui/pages/moderator/changes/changes'
+import '/imports/ui/pages/moderator/candidates/candidates'
 import '/imports/ui/pages/moderator/pardon/pardon'
 import '/imports/ui/pages/moderator/pardon/pardonUser'
 
@@ -237,6 +238,17 @@ modRoutes.route('/changes', {
 			header: 'header',
 			sidebar: 'sidebar',
     		main: 'changes'
+    	})
+	}
+})
+
+modRoutes.route('/candidates', {
+	name: 'candidates',
+	action: () => {
+		BlazeLayout.render('main', {
+			header: 'header',
+			sidebar: 'sidebar',
+    		main: 'candidates'
     	})
 	}
 })

--- a/imports/startup/server/index.js
+++ b/imports/startup/server/index.js
@@ -1,2 +1,3 @@
 import './fixtures'
 import './register-api'
+import './startup'

--- a/imports/startup/server/register-api.js
+++ b/imports/startup/server/register-api.js
@@ -3,6 +3,7 @@
 // user api
 import '/imports/api/user/methods'
 import '/imports/api/user/server/publications'
+import '/imports/api/user/server/startup'
 
 // news api
 import '/imports/api/news/methods'

--- a/imports/startup/server/startup.js
+++ b/imports/startup/server/startup.js
@@ -1,0 +1,5 @@
+import { Meteor } from 'meteor/meteor'
+
+Meteor.startup(() => {
+	SyncedCron.start()
+})

--- a/imports/ui/pages/moderator/candidates/candidates.html
+++ b/imports/ui/pages/moderator/candidates/candidates.html
@@ -1,0 +1,40 @@
+<template name="candidates">
+    <div class="news-list container-fluid">
+        <h2>Moderator candidates</h2>
+        <div class="row">
+            {{#if isModerator}}
+            <div class="col-sm-12">
+                <div class="changes-container">
+                {{#if SubsCacheReady}}
+                {{#if candidates.length}}
+                    <div class="row">
+                    {{#each candidates}}
+                        <div class="col-sm-12 card news-item">
+                            <div class="card-body">
+                                <div class="actions">
+                                    <a class="btn btn-sm btn-success" id="js-promote" href="#" role="button" title="Promote">
+                                        Promote
+                                    </a>
+                                </div>
+                                <a class="card-title" href="/profile/{{_id}}">{{profile.name}}</a>
+                                <p class="card-text">Input rating - {{fixed rating}}<br>Total input - {{totalInput}}<br>Rank - {{rank}}</p>
+                            </div>
+                        </div>
+                    {{/each}}
+                    </div>
+                {{else}}
+                    <div class="mt-3">
+                        <h3>No candidates found!</h3>
+                    </div>
+                {{/if}}
+                {{else}}
+                    {{> loader}}
+                {{/if}}
+                </div>
+            </div>
+            {{else}}
+                <h3>You have to be a moderator.</h3>
+            {{/if}}
+        </div>
+    </div>
+</template>

--- a/imports/ui/pages/moderator/candidates/candidates.js
+++ b/imports/ui/pages/moderator/candidates/candidates.js
@@ -1,0 +1,50 @@
+import './candidates.html'
+
+import { Template } from 'meteor/templating'
+import { FlowRouter } from 'meteor/kadira:flow-router'
+
+import { notify } from '/imports/modules/notifier'
+
+import { promoteUser } from '/imports/api/user/methods'
+
+import swal from 'sweetalert2'
+
+Template.candidates.onCreated(function() {
+	this.autorun(() => {
+		this.subscribe('users')
+	})
+})
+
+Template.candidates.helpers({
+	candidates: () => {
+		return Meteor.users.find({
+			'mod.candidate': true,
+			moderator: {
+				$ne: true
+			}
+		}).fetch().map(i => ({
+			profile: i.profile,
+			_id: i._id,
+			rating: i.mod.data.rating,
+			rank: i.mod.data.rank,
+			totalInput: i.mod.data.totalInput
+		})).sort((i1, i2) => i1.rank - i2.rank)
+	},
+	fixed: val => val.toFixed(2)
+})
+
+Template.candidates.events({
+	'click #js-promote': function(event, templateInstance) {
+		event.preventDefault()
+
+		promoteUser.call({
+			userId: this._id
+		}, (err, data) => {
+			if (err) {
+				notify(err.reason || err.message, 'error')
+			} else {
+				notify('Successfully promoted.', 'success')
+			}
+		})
+	}
+})

--- a/imports/ui/pages/moderator/candidates/candidates.ui-test.js
+++ b/imports/ui/pages/moderator/candidates/candidates.ui-test.js
@@ -1,0 +1,60 @@
+const assert = require('assert')
+const baseUrl = 'http://localhost:3000'
+
+describe('Candidates page', function () {
+    before(() => {
+        browser.url(`${baseUrl}/`)
+        browser.pause(5000)
+
+        browser.execute(() => {
+            Meteor.call('generateTestCandidate', (err, data) => {})
+
+            return 'ok'
+        })
+
+        browser.pause(5000)
+
+        browser.execute(() => {
+            Meteor.call('generateTestUser', (err, data) => {})
+
+            return 'ok'
+        })
+
+        browser.pause(5000)
+
+        browser.execute(() => Meteor.loginWithPassword('testing', 'testing'))
+
+        browser.pause(10000)
+    })
+
+    it('moderator can see candidates', function () {
+        browser.url(`${baseUrl}/moderator/candidates`)
+        browser.pause(5000)
+
+        assert(browser.execute(() => $('.news-item').length > 0).value, true)
+    })
+
+    it('moderator can promote candidates', function () {
+        let count = browser.execute(() => $('.news-item').length).value
+
+        let _id = browser.execute(() => $('.card-title').attr('href').split('/')[2]).value
+
+        browser.click('#js-promote')
+        browser.pause(2000)
+
+        let countN = browser.execute(() => $('.news-item').length).value
+
+        assert(count === countN + 1, true)
+        assert(browser.execute((_id) => Meteor.users.findOne({_id: _id}).moderator, _id), true)
+    })
+    
+    after(() => {
+        browser.execute(() => {
+            Meteor.call('removeTestCandidate', (err, data) => {})
+
+            return 'ok'
+        })
+
+        browser.pause(5000)
+    })
+})

--- a/imports/ui/shared/sidebar/sidebar.html
+++ b/imports/ui/shared/sidebar/sidebar.html
@@ -34,6 +34,11 @@
                 <i class="nav-icon icon-flag"></i> Proposed changes
               </a>
             </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/moderator/candidates">
+                <i class="nav-icon icon-users"></i> Moderator candidates
+              </a>
+            </li>
           </ul>
         </li>
         {{/if}}


### PR DESCRIPTION
Solution: Every 6 hours (cronjob) fetch a list of users and sort them by the amount of content they have created and calculate their input rating. From this list, take the top 10%. Allow existing moderators to promote new moderators from this list.