### PR TITLE
Problem: Location for events cannot be displayed on a map (#131)

### DIFF
--- a/client/head.html
+++ b/client/head.html
@@ -25,4 +25,6 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="/img/icons/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBdA0LxFu54uNoygUrX1lSVi0A0NLC18Lw&libraries=places"
+        async defer></script>
 </head>

--- a/imports/api/events/methods.js
+++ b/imports/api/events/methods.js
@@ -31,6 +31,10 @@ export const newEvent = new ValidatedMethod({
       max: 100,
       optional: false
     },
+    placeId: {
+      type: String,
+      optional: false
+    },
     rsvp: {
       type: String,
       optional: false
@@ -111,6 +115,10 @@ export const editEvent = new ValidatedMethod({
     location: {
       type: String,
       max: 100,
+      optional: false
+    },
+    placeId: {
+      type: String,
       optional: false
     },
     rsvp: {

--- a/imports/ui/pages/events/events.ui-test.js
+++ b/imports/ui/pages/events/events.ui-test.js
@@ -43,8 +43,10 @@ describe('Events page', function () {
         browser.setValue('#end_date', 'date2')
         browser.pause(1000)
 
-        browser.setValue('#location', 'City, Country')
+        browser.setValue('#location', 'Novi Sad, S')
         browser.pause(1000)
+        browser.click('.pac-item')
+        browser.pause(2000)
 
         browser.setValue('#rsvp', 'test')
         browser.pause(1000)


### PR DESCRIPTION
Solution: Use Google Maps Places API to autocomplete locations. Save place ID (internal google api identifier) of the location so it can be easily shown on a map later on.