### PR TITLE
Problem: github icon alignment is a bit off #133

### DIFF
--- a/imports/ui/shared/header/header.html
+++ b/imports/ui/shared/header/header.html
@@ -22,7 +22,7 @@
     </ul>
     <ul class="nav navbar-nav ml-auto  mr-3">
       <li class="nav-item d-md-down-none">
-        <a class="nav-link" target="blank" href="https://github.com/EmurgoHK/cardanoupdate">
+        <a class="nav-link" target="blank" style="padding-top : 2px;" href="https://github.com/EmurgoHK/cardanoupdate">
           <i class="nav-icon icon-social-github"></i>
         </a>
       </li>


### PR DESCRIPTION
Solution : Fixed by adding padding on top

Actually they are visually different icons (notifications and github) one has heavy weight on top and another just opposite, that's why that was looking off, simply added 2px padding on top for github icon.