### PR TITLE
problem: text layout on mobile is bad #172

### DIFF
--- a/imports/ui/pages/events/viewEvent.html
+++ b/imports/ui/pages/events/viewEvent.html
@@ -25,7 +25,7 @@
               <div class="col-sm-12">
                 <i class="icon-location-pin"></i> {{location}}
               </div>
-              <div class="col-sm-12 event-body pt-4 pl-5 pr-5">
+              <div class="col-sm-12 news-body pt-4 pl-3 pr-3 text-justify">
                 {{{md description}}}
               </div>
             </div>

--- a/imports/ui/pages/news/viewNews.html
+++ b/imports/ui/pages/news/viewNews.html
@@ -27,7 +27,7 @@
                 </div>
 
                 <div class="row mb-5">
-                  <div class="col-sm-12 news-body pt-4 pl-5 pr-5">
+                  <div class="col-sm-12 news-body pt-4 pl-3 pr-3 text-justify">
                     {{{md body}}}
                   </div>
                 </div>

--- a/imports/ui/pages/projects/viewProject.html
+++ b/imports/ui/pages/projects/viewProject.html
@@ -18,7 +18,7 @@
             <div class="card">
               <div class="card-body">
                 <div class="row mb-5">
-                  <div class="col-sm-12 news-body pt-4 pl-5 pr-5">
+                  <div class="col-sm-12 news-body pt-4 pl-3 pr-3 text-justify">
                     {{description}}
                   </div>
                 </div> 

--- a/imports/ui/pages/research/viewResearch.html
+++ b/imports/ui/pages/research/viewResearch.html
@@ -17,7 +17,7 @@
             <div class="card">
               <div class="card-body">
                 <div class="row">
-                  <div class="col-sm-12 abstract mt-3 mb-3">
+                  <div class="col-sm-12 abstract mt-3 mb-3 text-justify">
                     {{abstract}}
                   </div>
                 </div>

--- a/imports/ui/stylesheets/_custom.scss
+++ b/imports/ui/stylesheets/_custom.scss
@@ -38,7 +38,7 @@ body {
         .news-body {
             p {
                 font-size: 1.2rem !important;
-                word-spacing: 6px;
+                word-spacing: 3px;
                 @extend .card-text;
             }
         }


### PR DESCRIPTION
solution: reduced left and right padding in content description. applied .text-justify class and reduced word spacing to 3px