### PR TITLE
Problem: Users sometimes upload large images (#178)

### DIFF
--- a/imports/api/uploader/methods.js
+++ b/imports/api/uploader/methods.js
@@ -61,14 +61,21 @@ export const uploadImage = new ValidatedMethod({
             }))
 
             if (gm && gm.isAvailable) {
-                const size = {
-                    width: 100,
-                    height: 100
-                }
-
-                gm(`${uploadDir}${filename}`).resize(size.width, `${size.height}>`).gravity('Center').write(filenameThumbnail, error => {
+                gm(`${uploadDir}${filename}`).resize(200).gravity('Center').write(filenameThumbnail, error => {
                     if (error) {
-                        console.log('Error - ', error)
+                        console.log(error)
+                    }
+                })
+
+                gm(`${uploadDir}${filename}`).size((err, size) => {
+                    if (!err) {
+                        if (size.width > 960) { // max-width of the container
+                            gm(`${uploadDir}${filename}`).resize(960).gravity('Center').write(`${uploadDir}${filename}`, err => {
+                                if (err) {
+                                    console.log(err)
+                                }
+                            })
+                        }
                     }
                 })
             }

--- a/imports/ui/pages/home/home.html
+++ b/imports/ui/pages/home/home.html
@@ -42,7 +42,7 @@
             {{#each news}}
             <div class="col-sm-12 pr-0 pl-0">
               <div class="card news-item">
-              <img class="card-img-top d-sm-none" src="{{image}}" />
+              <img class="card-img-top d-sm-none" src="{{thumb}}" />
               <div class="card-body pb-0">
                 {{#if canEdit}}
                 <div class="news-settings float-right dropdown">

--- a/imports/ui/pages/home/home.js
+++ b/imports/ui/pages/home/home.js
@@ -32,6 +32,16 @@ Template.home.helpers({
     }
     return false
   },
+  thumb: function() {
+    if (this.image) {
+        let im = this.image.split('.')
+        let ext = im[im.length - 1]
+
+        return this.image.replace(`.${ext}`, `_thumbnail.${ext}`)
+    } 
+
+    return ''
+  },
   news: function(){
     let news = [];
     let searchText = Template.instance().searchFilter.get()

--- a/imports/ui/pages/home/home.scss
+++ b/imports/ui/pages/home/home.scss
@@ -33,7 +33,7 @@ a.read-more {
     width: 200px;
     
     img{
-      max-width: 100%;
+      width: 100%;
       height: auto;
     }
   }


### PR DESCRIPTION
Solution: Use graphicsmagik to scale down images wider than 960px (max width of the container). Also use graphicsmagick to create thumbnails (200px wide) for images and use them on the news list in order to prevent full-size images from loading unnecessarily.