### PR TITLE
Problem: Not clear to users how active the site is (#230)

### DIFF
--- a/imports/api/stats/methods.js
+++ b/imports/api/stats/methods.js
@@ -1,0 +1,64 @@
+import { Meteor } from 'meteor/meteor'
+import SimpleSchema from 'simpl-schema'
+import { ValidatedMethod } from 'meteor/mdg:validated-method'
+
+import { Stats } from './stats'
+
+import { Comments } from '/imports/api/comments/comments'
+import { Projects } from '/imports/api/projects/projects'
+import { Events } from '/imports/api/events/events'
+import { Research } from '/imports/api/research/research'
+import { socialResources } from '/imports/api/socialResources/socialResources'
+import { Learn } from '/imports/api/learn/learn'
+
+export const calculateStats = new ValidatedMethod({
+    name: 'calculateStats',
+    validate:
+        new SimpleSchema({}).validator({
+            clean: true
+        }),
+    run({}) {
+        let comments = Comments.find({
+            createdAt: {
+                $gt: new Date().getTime() - 30*1000*60*60*24
+            }
+        }).count()
+
+        let projects = Projects.find({
+            createdAt: {
+                $gt: new Date().getTime() - 30*1000*60*60*24
+            }
+        }).count()
+
+        let events = Events.find({
+            createdAt: {
+                $gt: new Date().getTime() - 30*1000*60*60*24
+            }
+        }).count()
+
+        let research = Research.find({
+            createdAt: {
+                $gt: new Date().getTime() - 30*1000*60*60*24
+            }
+        }).count()
+
+        let social = socialResources.find({
+            createdAt: {
+                $gt: new Date().getTime() - 30*1000*60*60*24
+            }
+        }).count()
+
+        let learn = Learn.find({
+            createdAt: {
+                $gt: new Date().getTime() - 30*1000*60*60*24
+            }
+        }).count()
+
+        Stats.upsert({
+            _id: 'last-month'
+        }, {
+            _id: 'last-month',
+            count: comments + projects + events + research + social + learn
+        })
+	}
+})

--- a/imports/api/stats/methods.test.js
+++ b/imports/api/stats/methods.test.js
@@ -1,0 +1,29 @@
+import { chai, assert } from 'chai'
+import { Meteor } from 'meteor/meteor'
+
+import { Stats } from './stats'
+import { callWithPromise } from '/imports/api/utilities'
+
+import './methods'
+
+Meteor.userId = () => 'test-user' // override the meteor userId, so we can test methods that require a user
+Meteor.users.findOne = () => ({ profile: { name: 'Test User'}, moderator: true }) // stub user data as well
+Meteor.user = () => ({ profile: { name: 'Test User'}, moderator: true })
+
+describe('stats methods', () => {
+    it('can calculate correct stats', () => {
+        return callWithPromise('calculateStats', {}).then(data => {
+            let stats = Stats.findOne({
+                _id: 'last-month'
+            })
+
+            assert.ok(stats)
+
+            assert.ok(stats.count >= 0)
+        })
+    })
+
+    after(function() {
+        Stats.remove({})
+    })
+})

--- a/imports/api/stats/server/publications.js
+++ b/imports/api/stats/server/publications.js
@@ -1,0 +1,5 @@
+import { Meteor } from 'meteor/meteor'
+
+import { Stats } from '../stats'
+
+Meteor.publish('stats', () => Stats.find({}))

--- a/imports/api/stats/server/startup.js
+++ b/imports/api/stats/server/startup.js
@@ -1,0 +1,18 @@
+import { Meteor } from 'meteor/meteor'
+
+import { calculateStats } from '/imports/api/stats/methods'
+import { Stats } from '/imports/api/stats/stats'
+
+Meteor.startup(() => {
+  	SyncedCron.add({
+    	name: 'Calculate stats',
+    	schedule: (parser) => parser.cron('*/15 * * * *'), // every 15 minutes will be sufficient
+    	job: () => calculateStats.call({}, (err, data) => {})
+  	})
+
+  	if (!Stats.findOne({
+  		_id: 'last-month'
+  	})) {
+  		calculateStats.call({}, (err, data) => {})
+  	}
+})

--- a/imports/api/stats/stats.js
+++ b/imports/api/stats/stats.js
@@ -1,0 +1,3 @@
+import { Mongo } from 'meteor/mongo'
+
+export const Stats = new Mongo.Collection('stats')

--- a/imports/startup/server/register-api.js
+++ b/imports/startup/server/register-api.js
@@ -7,6 +7,12 @@ import '/imports/api/user/server/publications'
 import '/imports/api/user/server/startup'
 import '/imports/api/user/usersStats'
 
+// stats api
+import '/imports/api/stats/methods'
+import '/imports/api/stats/stats'
+import '/imports/api/stats/server/publications'
+import '/imports/api/stats/server/startup'
+
 // news api
 import '/imports/api/news/methods'
 import '/imports/api/news/server/publications'

--- a/imports/ui/pages/home/home.html
+++ b/imports/ui/pages/home/home.html
@@ -48,7 +48,7 @@
                   </div>
                   <i class="icon-speech"></i>
                 </h5>
-                <span class="text-muted text-uppercase font-weight-bold h6">Comments this month</span>
+                <span class="text-muted text-uppercase font-weight-bold h6">Content this month</span>
               </div>
             </div>
           </div>

--- a/imports/ui/pages/home/home.js
+++ b/imports/ui/pages/home/home.js
@@ -8,6 +8,7 @@ import { Research } from '/imports/api/research/research'
 import { Learn } from '/imports/api/learn/learn'
 import { socialResources } from '/imports/api/socialResources/socialResources'
 import { UsersStats } from '/imports/api/user/usersStats'
+import { Stats } from '/imports/api/stats/stats'
 import moment from 'moment'
 
 import swal from 'sweetalert2'
@@ -23,6 +24,7 @@ Template.home.onCreated(function () {
     this.subscribe('comments')
     this.subscribe('usersStats')
     this.subscribe('learn')
+    this.subscribe('stats')
   })
 })
 
@@ -103,9 +105,9 @@ Template.home.helpers({
     _id: 'lastMonth'
   }) || {}).created || 0,
 
-  commentsLastMonth: () => (UsersStats.findOne({
-    _id: 'lastMonthComments'
-  }) || {}).created || 0,
+    commentsLastMonth: () => (Stats.findOne({
+        _id: 'last-month'
+    }) || {}).count || 0,
 
   onlineUsers() {
     let connectionUsers = ((UsersStats.findOne("connected") || {}).userIds || []).length;


### PR DESCRIPTION
Solution: Change the "new comments this month" to reflect all new content in the last 30 days. Comments on everything as well as the number of new items themselves. SyncedCron is used to generate this number every 15 minutes.