### PR TITLE
Problem: Content flagging is ambiguous (#219)

### DIFF
--- a/imports/modules/flagDialog.js
+++ b/imports/modules/flagDialog.js
@@ -1,0 +1,39 @@
+import swal from 'sweetalert2'
+import { notify } from '/imports/modules/notifier'
+
+// modularize the flag dialog so we don't have to repeat this code everywhere
+// plus, it's also a lot easier to modify it this way
+
+// fcn is the function that's called when an item is flagged (i.e. flagProject)
+// field represents the field name for _id in method call (i.e. projectId)
+// msg is a custom message that will be displayed to the user on successfull flagging
+export const flagDialog = function(fcn, field, msg) {
+    swal({
+        title: 'Why are you reporting this?',
+        html: `<div class="p-3"><span id="spam" class="flag-action btn btn-warning p-3" style="width: 40%">This is spam</span>
+               <span id="scam" class="flag-action btn btn-danger p-3" style="width: 40%">This is a scam</span></div>`,
+        showCancelButton: true,
+        showConfirmButton: false
+    }).then(data => {
+        if (!data.value) {
+            $(document).off('click', '.flag-action')
+        }
+    })
+
+    $(document).on('click', '.flag-action', (event) => {
+        fcn.call({
+            [field]: this._id,
+            reason: $(event.currentTarget).text().trim()
+        }, (err, data) => {
+            swal.close()
+
+            if (err) {
+                notify(err.reason || err.message, 'error')
+            } else {
+                notify(msg || 'Successfully flagged. Moderators will decide what to do next.', 'success')
+            }
+        })
+
+        $(document).off('click', '.flag-action') // prevent multiple handlers
+    })
+}

--- a/imports/ui/pages/comments/commentBody.html
+++ b/imports/ui/pages/comments/commentBody.html
@@ -5,7 +5,7 @@
             <div class="news-settings float-right dropdown" style="margin-top: -10px;">
                 <i class="nav-icon icon-settings dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></i>
                 <div class="dropdown-menu">
-                    <a class="dropdown-item flag-comment" href="#"><i class="icon-flag text-dark"></i> Flag</a>
+                    <a class="dropdown-item flag-comment" href="#" title="Report"><i class="fas fa-exclamation-triangle text-dark"></i> Flag</a>
                     {{#if canEditComment}}
                     <a class="dropdown-item edit-mode" href="#"><i class="icon-pencil text-dark"></i> Edit</a>
                     <a class="dropdown-item text-danger delete-comment" href="#"><i class="icon-trash text-danger"></i> Delete</a>

--- a/imports/ui/pages/events/events.html
+++ b/imports/ui/pages/events/events.html
@@ -37,8 +37,8 @@
           <p>{{rsvp}}</p>
           <P>
             <i class="icon-location-pin"></i> {{location}}
-            <a class="flag-event float-right" href="#" title="Flag this event">
-              <i class="icon-flag"></i>
+            <a class="flag-event float-right" href="#" title="Report">
+              <i class="fas fa-exclamation-triangle"></i>
             </a>
           </P>
         </div>

--- a/imports/ui/pages/events/events.js
+++ b/imports/ui/pages/events/events.js
@@ -8,6 +8,8 @@ import { notify } from '/imports/modules/notifier'
 import swal from 'sweetalert2'
 import moment from 'moment'
 
+import { flagDialog } from '/imports/modules/flagDialog'
+
 const CHUNK_SIZE = 3
 
 Template.events.onCreated(function () {
@@ -66,26 +68,7 @@ Template.events.events({
   },
   'click .flag-event' : function (event, templateInstance){
     event.preventDefault()
-    swal({
-      title: 'Why are you flagging this?',
-      input: 'text',
-      showCancelButton: true,
-      inputValidator: (value) => {
-        return !value && 'You need to write a valid reason!'
-      }
-    }).then(data => {
-      if (data.value) {
-        flagEvent.call({
-          eventId: this._id,
-          reason: data.value
-        }, (err, data) => {
-          if (err) {
-            notify(err.reason || err.message, 'error')
-          } else {
-            notify('Successfully flagged. Moderators will decide what to do next.', 'success')
-          }
-        })
-      }
-    })
+
+    flagDialog.call(this, flagEvent, 'eventId')
   }
 })

--- a/imports/ui/pages/events/events.ui-test.js
+++ b/imports/ui/pages/events/events.ui-test.js
@@ -86,10 +86,7 @@ describe('Events page', function () {
         browser.click('.flag-event')
         browser.pause(2000)
 
-        browser.setValue('.swal2-input', 'Test flag event')
-        browser.pause(1000)
-
-        browser.click('.swal2-confirm')
+        browser.click('#spam')
         browser.pause(3000)
     })
 

--- a/imports/ui/pages/events/viewEvent.html
+++ b/imports/ui/pages/events/viewEvent.html
@@ -31,7 +31,7 @@
             </div>
             <div class="row">
               <div class="col-sm-12">
-                <a class="btn btn-secondary flag-event" href="#"><i class="icon-flag"></i></a>
+                <a class="btn btn-secondary flag-event" href="#" title="Report"><i class="fas fa-exclamation-triangle"></i></a>
                 {{#if watching}}
                 <a class="btn btn-success watch-event" href="#" title="Unwatch"><i class="icon-eye"></i></a>
                 {{else}}

--- a/imports/ui/pages/events/viewEvent.js
+++ b/imports/ui/pages/events/viewEvent.js
@@ -9,6 +9,8 @@ import { newComment } from '/imports/api/comments/methods'
 import { flagEvent, toggleWatchEvents } from '/imports/api/events/methods'
 import { notify } from '/imports/modules/notifier'
 
+import { flagDialog } from '/imports/modules/flagDialog'
+
 import swal from 'sweetalert2'
 
 Template.viewEvent.onCreated(function () {
@@ -69,27 +71,7 @@ Template.viewEvent.events({
 			slug: FlowRouter.getParam('slug')
 		}) || {}
 
-		swal({
-		  	title: 'Why are you flagging this?',
-		  	input: 'text',
-		  	showCancelButton: true,
-		  	inputValidator: (value) => {
-		    	return !value && 'You need to write a valid reason!'
-		  	}
-		}).then(data => {
-			if (data.value) {
-				flagEvent.call({
-					eventId: event._id,
-					reason: data.value
-				}, (err, data) => {
-					if (err) {
-						notify(err.reason || err.message, 'error')
-					} else {
-						notify('Successfully flagged. Moderators will decide what to do next.', 'success')
-					}
-				})
-			}
-		})
+		flagDialog.call(event, flagEvent, 'eventId')
 	},
 	'click .new-comment': (e, templateInstance) => {
 		e.preventDefault()

--- a/imports/ui/pages/home/home.html
+++ b/imports/ui/pages/home/home.html
@@ -95,8 +95,8 @@
                                   {{/unless}}
                                   <a href="{{github_url}}" class="github new-link card-link"><i class="fab fa-github fa-lg"></i></a>
                                   <a href="{{website}}" class="website new-link card-link"><i class="fas fa-globe fa-lg"></i></a>
-                                  <a class="flag-project float-right" href="#" title="Flag this project">
-                                    <i class="icon-flag"></i>
+                                  <a class="flag-project float-right" href="#" title="Report">
+                                    <i class="fas fa-exclamation-triangle"></i>
                                   </a>
                               </div>
                           </div>
@@ -145,8 +145,8 @@
                                 <p>{{rsvp}}</p>
                                 <P>
                                   <i class="icon-location-pin"></i> {{location}}
-                                  <a class="flag-event float-right" href="#" title="Flag this event">
-                                    <i class="icon-flag"></i>
+                                  <a class="flag-event float-right" href="#" title="Report">
+                                    <i class="fas fa-exclamation-triangle"></i>
                                   </a>
                                 </P>
                               </div>
@@ -193,8 +193,8 @@
                                   </p>
                                   <hr>
                                   <a href="{{pdf}}" class="card-link"><i class="far fa-file-pdf"></i></a>
-                                  <a class="flag-research float-right" href="#" title="Flag this research">
-                                    <i class="icon-flag"></i>
+                                  <a class="flag-research float-right" href="#" title="Report">
+                                    <i class="fas fa-exclamation-triangle"></i>
                                   </a>
                               </div>
                           </div>
@@ -233,6 +233,9 @@
                                   <h4 class="card-title">
                                       <a href="/learn/{{slug}}">{{title}}</a>
                                   </h4>
+                                  <a class="flag-learn float-right" href="#" title="Report">
+                                    <i class="fas fa-exclamation-triangle"></i>
+                                  </a>
                               </div>
                           </div>
                       </div>

--- a/imports/ui/pages/home/home.js
+++ b/imports/ui/pages/home/home.js
@@ -11,6 +11,13 @@ import { UsersStats } from '/imports/api/user/usersStats'
 import { Stats } from '/imports/api/stats/stats'
 import moment from 'moment'
 
+import { flagResearch } from '/imports/api/research/methods'
+import { flagProject } from '/imports/api/projects/methods'
+import { flagEvent } from '/imports/api/events/methods'
+import { flagLearningItem } from '/imports/api/learn/methods'
+
+import { flagDialog } from '/imports/modules/flagDialog'
+
 import swal from 'sweetalert2'
 
 Template.home.onCreated(function () {
@@ -135,75 +142,23 @@ Template.home.events({
   },
   'click .flag-research' : function(event, templateInstance) {
     event.preventDefault()
-    swal({
-        title: 'Why are you flagging this?',
-        input: 'text',
-        showCancelButton: true,
-        inputValidator: (value) => {
-            return !value && 'You need to write a valid reason!'
-        }
-    }).then(data => {
-        if (data.value) {
-            flagResearch.call({
-                researchId: this._id,
-                reason: data.value
-            }, (err, data) => {
-                if (err) {
-                    notify(err.reason || err.message, 'error')
-                } else {
-                    notify('Successfully flagged. Moderators will decide what to do next.', 'success')
-                }
-            })
-        }
-    })
+    
+    flagDialog.call(this, flagResearch, 'researchId')
   },
-  'click .flag-project' : function (event, templateInstance){
+  'click .flag-learn' : function(event, templateInstance) {
     event.preventDefault()
-    swal({
-      title: 'Why are you flagging this?',
-      input: 'text',
-      showCancelButton: true,
-      inputValidator: (value) => {
-        return !value && 'You need to write a valid reason!'
-      }
-    }).then(data => {
-      if (data.value) {
-        flagProject.call({
-          projectId: this._id,
-          reason: data.value
-        }, (err, data) => {
-          if (err) {
-            notify(err.reason || err.message, 'error')
-          } else {
-            notify('Successfully flagged. Moderators will decide what to do next.', 'success')
-          }
-        })
-      }
-    })
+    
+    flagDialog.call(this, flagLearningItem, 'learnId')
   },
-  'click .flag-event' : function (event, templateInstance){
+  'click .flag-project' : function(event, templateInstance) {
     event.preventDefault()
-    swal({
-      title: 'Why are you flagging this?',
-      input: 'text',
-      showCancelButton: true,
-      inputValidator: (value) => {
-        return !value && 'You need to write a valid reason!'
-      }
-    }).then(data => {
-      if (data.value) {
-        flagEvent.call({
-          eventId: this._id,
-          reason: data.value
-        }, (err, data) => {
-          if (err) {
-            notify(err.reason || err.message, 'error')
-          } else {
-            notify('Successfully flagged. Moderators will decide what to do next.', 'success')
-          }
-        })
-      }
-    })
+    
+    flagDialog.call(this, flagProject, 'projectId')
+  },
+  'click .flag-event' : function(event, templateInstance) {
+    event.preventDefault()
+    
+    flagDialog.call(this, flagEvent, 'eventId')
   },
     'click .new-link': function(event, temlateInstance) {
         if ($(event.currentTarget).attr('href')) {

--- a/imports/ui/pages/learn/learn.html
+++ b/imports/ui/pages/learn/learn.html
@@ -39,8 +39,8 @@
                     <h4 class="card-title">
                         <a href="/learn/{{slug}}">{{title}}</a>
                     </h4>
-                    <a class="flag-learn float-right" href="#" title="Flag this learning item">
-                      <i class="icon-flag"></i>
+                    <a class="flag-learn float-right" href="#" title="Report">
+                      <i class="fas fa-exclamation-triangle"></i>
                     </a>
                 </div>
             </div>

--- a/imports/ui/pages/learn/learn.js
+++ b/imports/ui/pages/learn/learn.js
@@ -8,6 +8,7 @@ import { removeLearningItem, flagLearningItem } from '/imports/api/learn/methods
 import swal from 'sweetalert2'
 
 import { notify } from '/imports/modules/notifier'
+import { flagDialog } from '/imports/modules/flagDialog'
 
 const CHUNK_SIZE = 3
 
@@ -77,26 +78,7 @@ Template.learn.events({
     },
     'click .flag-learn' : function(event, templateInstance) {
         event.preventDefault()
-        swal({
-            title: 'Why are you flagging this?',
-            input: 'text',
-            showCancelButton: true,
-            inputValidator: (value) => {
-                return !value && 'You need to write a valid reason!'
-            }
-        }).then(data => {
-            if (data.value) {
-                flagLearningItem.call({
-                    learnId: this._id,
-                    reason: data.value
-                }, (err, data) => {
-                    if (err) {
-                        notify(err.reason || err.message, 'error')
-                    } else {
-                        notify('Successfully flagged. Moderators will decide what to do next.', 'success')
-                    }
-                })
-            }
-        })
+
+        flagDialog.call(this, flagLearningItem, 'learnId')
     }
 })

--- a/imports/ui/pages/learn/learn.ui-test.js
+++ b/imports/ui/pages/learn/learn.ui-test.js
@@ -79,10 +79,7 @@ describe('Learn page', function () {
         browser.click('.flag-learn')
         browser.pause(2000)
 
-        browser.setValue('.swal2-input', 'Test flag learn')
-        browser.pause(1000)
-
-        browser.click('.swal2-confirm')
+        browser.click('#spam')
         browser.pause(3000)
     })
 

--- a/imports/ui/pages/learn/viewLearn.html
+++ b/imports/ui/pages/learn/viewLearn.html
@@ -35,7 +35,7 @@
 
                 <div class="row">
                   <div class="col-sm-12">
-                      <a class="btn btn-secondary flag-learn" href="#"><i class="icon-flag"></i></a>
+                      <a class="btn btn-secondary flag-learn" href="#" title="Report"><i class="fas fa-exclamation-triangle"></i></a>
                   </div>
                 </div>
               </div>

--- a/imports/ui/pages/learn/viewLearn.js
+++ b/imports/ui/pages/learn/viewLearn.js
@@ -11,6 +11,7 @@ import { newComment } from '/imports/api/comments/methods'
 import { flagLearningItem } from '/imports/api/learn/methods'
 
 import { notify } from '/imports/modules/notifier'
+import { flagDialog } from '/imports/modules/flagDialog'
 
 import swal from 'sweetalert2'
 
@@ -71,27 +72,7 @@ Template.viewLearn.events({
 			slug: FlowRouter.getParam('slug')
 		}) || {}
 
-		swal({
-		  	title: 'Why are you flagging this?',
-		  	input: 'text',
-		  	showCancelButton: true,
-		  	inputValidator: (value) => {
-		    	return !value && 'You need to write a valid reason!'
-		  	}
-		}).then(data => {
-			if (data.value) {
-				flagLearningItem.call({
-					learnId: learn._id,
-					reason: data.value
-				}, (err, data) => {
-					if (err) {
-						notify(err.reason || err.message, 'error')
-					} else {
-						notify('Successfully flagged. Moderators will decide what to do next.', 'success')
-					}
-				})
-			}
-		})
+		flagDialog.call(learn, flagLearningItem, 'learnId')
 	},
 	'click .new-comment': (event, templateInstance) => {
 		event.preventDefault()

--- a/imports/ui/pages/moderator/flagged/flaggedItems.js
+++ b/imports/ui/pages/moderator/flagged/flaggedItems.js
@@ -72,7 +72,7 @@ Template.flaggedItems.helpers({
 
 		return _.union(research, events, comments, news, projects, learn).map(i => ({
 			_id: i._id,
-			link: i.content ? `/learn/${i.slug}` : (i.pdf ? `/research/${i.slug}` : (i.location ? `/events/${i.slug}` : (i.summary ? `/news/${i.slug}` : (i.description ? `/project/${i.slug}` : '')))),
+			link: i.content ? `/learn/${i.slug}` : (i.pdf ? `/research/${i.slug}` : (i.location ? `/events/${i.slug}` : (i.summary ? `/news/${i.slug}` : (i.description ? `/projects/${i.slug}` : '')))),
 			text: i.title ? i.title : (i.headline ? i.headline : i.text),
 			reasons: i.flags.map(j => ({
 				reason: j.reason,

--- a/imports/ui/pages/projects/projects.html
+++ b/imports/ui/pages/projects/projects.html
@@ -49,8 +49,8 @@
                     {{/unless}}
                     <a href="{{github_url}}" class="github card-link"><i class="fab fa-github fa-lg"></i></a>
                     <a href="{{website}}" class="website card-link"><i class="fas fa-globe fa-lg"></i></a>
-                    <a class="flag-project float-right" href="#" title="Flag this project">
-                      <i class="icon-flag"></i>
+                    <a class="flag-project float-right" href="#" title="Report">
+                      <i class="fas fa-exclamation-triangle"></i>
                     </a>
                 </div>
             </div>

--- a/imports/ui/pages/projects/projects.js
+++ b/imports/ui/pages/projects/projects.js
@@ -9,6 +9,8 @@ import swal from 'sweetalert2'
 
 import { notify } from '/imports/modules/notifier'
 
+import { flagDialog } from '/imports/modules/flagDialog'
+
 const CHUNK_SIZE = 3
 
 Template.projects.onCreated(function () {
@@ -146,26 +148,7 @@ Template.projects.events({
 
     'click .flag-project' : function (event, templateInstance){
       event.preventDefault()
-      swal({
-		  	title: 'Why are you flagging this?',
-		  	input: 'text',
-		  	showCancelButton: true,
-		  	inputValidator: (value) => {
-		    	return !value && 'You need to write a valid reason!'
-		  	}
-      }).then(data => {
-        if (data.value) {
-          flagProject.call({
-            projectId: this._id,
-            reason: data.value
-          }, (err, data) => {
-            if (err) {
-              notify(err.reason || err.message, 'error')
-            } else {
-              notify('Successfully flagged. Moderators will decide what to do next.', 'success')
-            }
-          })
-        }
-      })
+      
+      flagDialog.call(this, flagProject, 'projectId')
     }
 })

--- a/imports/ui/pages/projects/projects.ui-test.js
+++ b/imports/ui/pages/projects/projects.ui-test.js
@@ -96,10 +96,7 @@ describe('Projects page', function () {
         browser.click('.flag-project')
         browser.pause(2000)
 
-        browser.setValue('.swal2-input', 'Test flag project')
-        browser.pause(1000)
-
-        browser.click('.swal2-confirm')
+        browser.click('#spam')
         browser.pause(3000)
     })
 

--- a/imports/ui/pages/projects/viewProject.html
+++ b/imports/ui/pages/projects/viewProject.html
@@ -40,7 +40,7 @@
                       {{/unless}}
                       <a href="{{github_url}}" class="btn btn-dark text-white github"><i class="fab fa-github fa-lg"></i></a>
                       <a href="{{website}}" class="btn btn-secondary website"><i class="fas fa-globe fa-lg"></i></a>
-                      <a class="btn btn-secondary flag-project" href="#"><i class="icon-flag"></i></a>
+                      <a class="btn btn-secondary flag-project" href="#" title="Report"><i class="fas fa-exclamation-triangle"></i></a>
                   </div>
                 </div>
 

--- a/imports/ui/pages/projects/viewProject.js
+++ b/imports/ui/pages/projects/viewProject.js
@@ -12,6 +12,8 @@ import { flagProject } from '/imports/api/projects/methods'
 
 import { notify } from '/imports/modules/notifier'
 
+import { flagDialog } from '/imports/modules/flagDialog'
+
 import swal from 'sweetalert2'
 
 Template.viewProject.onCreated(function() {
@@ -101,27 +103,7 @@ Template.viewProject.events({
 			slug: FlowRouter.getParam('slug')
 		}) || {}
 
-		swal({
-		  	title: 'Why are you flagging this?',
-		  	input: 'text',
-		  	showCancelButton: true,
-		  	inputValidator: (value) => {
-		    	return !value && 'You need to write a valid reason!'
-		  	}
-		}).then(data => {
-			if (data.value) {
-				flagProject.call({
-					projectId: project._id,
-					reason: data.value
-				}, (err, data) => {
-					if (err) {
-						notify(err.reason || err.message, 'error')
-					} else {
-						notify('Successfully flagged. Moderators will decide what to do next.', 'success')
-					}
-				})
-			}
-		})
+		flagDialog.call(project, flagProject, 'projectId')
 	},
 	'click .new-cool, click .new-flag': (event, templateInstance) => {
 		event.preventDefault()

--- a/imports/ui/pages/research/research.html
+++ b/imports/ui/pages/research/research.html
@@ -45,8 +45,8 @@
                     </p>
                     <hr>
                     <a href="{{pdf}}" class="card-link"><i class="far fa-file-pdf"></i></a>
-                    <a class="flag-research float-right" href="#" title="Flag this research">
-                      <i class="icon-flag"></i>
+                    <a class="flag-research float-right" href="#" title="Report">
+                      <i class="fas fa-exclamation-triangle"></i>
                     </a>
                 </div>
             </div>

--- a/imports/ui/pages/research/research.js
+++ b/imports/ui/pages/research/research.js
@@ -8,6 +8,7 @@ import { removeResearch, flagResearch } from '/imports/api/research/methods'
 import swal from 'sweetalert2'
 
 import { notify } from '/imports/modules/notifier'
+import { flagDialog } from '/imports/modules/flagDialog'
 
 const CHUNK_SIZE = 3
 
@@ -76,26 +77,7 @@ Template.research.events({
     },
     'click .flag-research' : function(event, templateInstance) {
         event.preventDefault()
-        swal({
-            title: 'Why are you flagging this?',
-            input: 'text',
-            showCancelButton: true,
-            inputValidator: (value) => {
-                return !value && 'You need to write a valid reason!'
-            }
-        }).then(data => {
-            if (data.value) {
-                flagResearch.call({
-                    researchId: this._id,
-                    reason: data.value
-                }, (err, data) => {
-                    if (err) {
-                        notify(err.reason || err.message, 'error')
-                    } else {
-                        notify('Successfully flagged. Moderators will decide what to do next.', 'success')
-                    }
-                })
-            }
-        })
+        
+        flagDialog.call(this, flagResearch, 'researchId')
     }
 })

--- a/imports/ui/pages/research/research.ui-test.js
+++ b/imports/ui/pages/research/research.ui-test.js
@@ -87,10 +87,7 @@ describe('Research page', function () {
         browser.click('.flag-research')
         browser.pause(2000)
 
-        browser.setValue('.swal2-input', 'Test flag research')
-        browser.pause(1000)
-
-        browser.click('.swal2-confirm')
+        browser.click('#spam')
         browser.pause(3000)
     })
 

--- a/imports/ui/pages/research/viewResearch.html
+++ b/imports/ui/pages/research/viewResearch.html
@@ -30,7 +30,7 @@
 
                 <div class="row">
                   <div class="col-sm-12">
-                      <a class="btn btn-secondary flag-research" href="#"><i class="icon-flag"></i></a>
+                      <a class="btn btn-secondary flag-research" href="#" title="Report"><i class="fas fa-exclamation-triangle"></i></a>
                   </div>
                 </div>
               </div>

--- a/imports/ui/pages/research/viewResearch.js
+++ b/imports/ui/pages/research/viewResearch.js
@@ -8,9 +8,10 @@ import { Research } from '/imports/api/research/research'
 import { Comments } from '/imports/api/comments/comments'
 
 import { newComment } from '/imports/api/comments/methods' 
-import { flagResarch } from '/imports/api/research/methods'
+import { flagResearch } from '/imports/api/research/methods'
 
 import { notify } from '/imports/modules/notifier'
+import { flagDialog } from '/imports/modules/flagDialog'
 
 import swal from 'sweetalert2'
 
@@ -70,27 +71,7 @@ Template.viewResearch.events({
 			slug: FlowRouter.getParam('slug')
 		}) || {}
 
-		swal({
-		  	title: 'Why are you flagging this?',
-		  	input: 'text',
-		  	showCancelButton: true,
-		  	inputValidator: (value) => {
-		    	return !value && 'You need to write a valid reason!'
-		  	}
-		}).then(data => {
-			if (data.value) {
-				flagResarch.call({
-					researchId: research._id,
-					reason: data.value
-				}, (err, data) => {
-					if (err) {
-						notify(err.reason || err.message, 'error')
-					} else {
-						notify('Successfully flagged. Moderators will decide what to do next.', 'success')
-					}
-				})
-			}
-		})
+		flagDialog.call(research, flagResearch, 'researchId')
 	},
 	'click .new-comment': (event, templateInstance) => {
 		event.preventDefault()


### PR DESCRIPTION
Solution: Use the `exclamation-triangle` icon and add a tooltip that says `Report` on hover. Instead of the text input, give two options: `This is spam` and `This is a scam`. Update appropriate tests.