### PR TITLE
Problem: RSVP on event creation doesn't have instructions (#214)

### DIFF
--- a/imports/ui/pages/events/eventForm.html
+++ b/imports/ui/pages/events/eventForm.html
@@ -40,9 +40,9 @@
                 <input type="text" class="form-control" id="location" value="{{event.location}}" placeholder="Event Location">
                 <div id="locationError" class="invalid-feedback"></div>
               </div>
-              <div class="group-title">RSVP</div>
+              <div class="group-title">RSVP link</div>
               <div class="input-group">
-                <input type="text" class="form-control" id="rsvp" value="{{event.rsvp}}" placeholder="Event RSVP">
+                <input type="text" class="form-control" id="rsvp" value="{{event.rsvp}}" placeholder="Where should people RSVP if they want to attend this event?">
                 <div id="rsvpError" class="invalid-feedback"></div>
               </div>
             </form>


### PR DESCRIPTION
Solution: Change `RSVP` to `RSVP link` and set field hint to `Where should people RSVP if they want to attend this event?`.