### PR TITLE
Problem: tag input too wide on mobiles /projects #347

### DIFF
--- a/imports/ui/pages/projects/projectForm.html
+++ b/imports/ui/pages/projects/projectForm.html
@@ -35,7 +35,7 @@
               </div>
               <div class="group-title">Tags</div>
               <div class="input-group">
-                <select multiple="true" name="tags[]" id="tags" class="form-control select2">
+                <select multiple="true" name="tags[]" id="tags" class="form-control">
                   {{#each tags}}
                   <option value="{{name}}">{{name}}</option>
                   {{/each}}


### PR DESCRIPTION
Problem: tag input too wide on mobiles /projects #347 
Solution: Remove unwanted class provided to tag.