### PR TITLE
Problem: search-bar cross not working, when search from header top-right side #528

### DIFF
--- a/imports/ui/shared/searchBar/searchBar.js
+++ b/imports/ui/shared/searchBar/searchBar.js
@@ -49,7 +49,9 @@ Template.searchBar.events({
     		let routeType = searchFromLocation.type ? searchFromLocation.type.trim() : null ;
     		if(routeType && routeType.length > 0){
     			FlowRouter.go('/'+routeType);
-    		}
+    		} else {
+                FlowRouter.go('/');
+            }
     	}
 
     }


### PR DESCRIPTION
Solution: Need to check /search and if any type is not exist then move to home page.