### PR TITLE
Problem: [Community] search bar cross button not working

### DIFF
--- a/imports/ui/shared/searchBar/searchBar.js
+++ b/imports/ui/shared/searchBar/searchBar.js
@@ -48,6 +48,9 @@ Template.searchBar.events({
 			{}
     		let routeType = searchFromLocation.type ? searchFromLocation.type.trim() : null ;
     		if(routeType && routeType.length > 0){
+                if(routeType == "socialResources"){
+                    routeType = "community"
+                }
     			FlowRouter.go('/'+routeType);
     		} else {
                 FlowRouter.go('/');


### PR DESCRIPTION
Solution: If socialResources then redirect on community.