### PR TITLE
Problem: [SideMenu] Select Language item need proper space #618

### DIFF
--- a/imports/ui/shared/sidebar/sidebar.html
+++ b/imports/ui/shared/sidebar/sidebar.html
@@ -67,8 +67,8 @@
         </li>
         {{/if}}
         <li class="nav-item">
-          <div class="change-language">
-              <select name="selectLanguage" id="selectLanguage" style="width:90%">
+          <div class="change-language nav-link">
+              <select name="selectLanguage" id="selectLanguage" class="form-control" style="width:100%">
                 {{#each languages}}
                   {{#if selected}}
                     <option value={{code}} selected>{{name}}</option>


### PR DESCRIPTION
Solution: Add space between language selection and above item, add style for select box also