### PR TITLE
Problem: [Search] if no search text in input, no need 'x' icon #719

### DIFF
--- a/imports/ui/shared/searchBar/searchBar.html
+++ b/imports/ui/shared/searchBar/searchBar.html
@@ -3,7 +3,7 @@
     <div class="col-sm-12">
         <div class="input-group">
             <input type="text" id="searchBox" class="form-control" placeholder="{{ placeholder }}" aria-label="{{ placeholder }}" value="{{searchTerm}}">
-            <i class="fas fa-times search-bar-cross"></i>
+            {{#if searchTerm}}<i class="fas fa-times search-bar-cross"></i>{{/if}}
         </div>
         {{#if type}}
         <a class="advancedSearchLink" href="{{ advancedSearchUrl }}">{{_ "search.advanced"}} &#x25c0;</a>

--- a/imports/ui/stylesheets/_custom.scss
+++ b/imports/ui/stylesheets/_custom.scss
@@ -226,7 +226,7 @@ button {
 
 .search-bar-cross{
     position: absolute;
-    margin-left: 95%;
+    right: 12px;
     margin-top: 10px;
     cursor: pointer;
     z-index: 3;


### PR DESCRIPTION
Solution: Only display search clear icon only if search applied